### PR TITLE
refactor(config): AWS 인증을 정적 키에서 인스턴스 역할로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,6 @@ jobs:
           NAVER_MAP_CLIENT_SECRET: ${{ secrets.NAVER_MAP_CLIENT_SECRET }}
           KAKAO_API_KEY: ${{ secrets.KAKAO_API_KEY }}
           REDIS_HOST: ${{secrets.REDIS_HOST}}
-          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
           AWS_BEDROCK_MODEL_ID: ${{ secrets.AWS_BEDROCK_MODEL_ID }}
           SES_SNS_SECRET_TOKEN: ${{ secrets.SES_SNS_SECRET_TOKEN }}
           SES_SNS_TOPIC_ARN: ${{ secrets.SES_SNS_TOPIC_ARN }}
@@ -166,9 +164,6 @@ jobs:
           
           cloud:
             aws:
-              credentials:
-                access-key: ${AWS_ACCESS_KEY}
-                secret-key: ${AWS_SECRET_KEY}
               region:
                 static: ap-northeast-2
               bedrock:

--- a/src/main/java/server/nadeliv/config/AwsS3Config.java
+++ b/src/main/java/server/nadeliv/config/AwsS3Config.java
@@ -3,19 +3,12 @@ package server.nadeliv.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 public class AwsS3Config {
-
-    @Value("${cloud.aws.credentials.access-key}")
-    private String accessKey;
-
-    @Value("${cloud.aws.credentials.secret-key}")
-    private String secretKey;
 
     @Value("${cloud.aws.region.static:ap-northeast-2}")
     private String region;
@@ -24,9 +17,7 @@ public class AwsS3Config {
     public S3Client s3Client() {
         return S3Client.builder()
                 .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)
-                ))
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 }

--- a/src/main/java/server/nadeliv/config/AwsTranslateConfig.java
+++ b/src/main/java/server/nadeliv/config/AwsTranslateConfig.java
@@ -3,8 +3,7 @@ package server.nadeliv.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
@@ -17,12 +16,6 @@ import java.time.Duration;
 @Configuration
 public class AwsTranslateConfig {
 
-    @Value("${cloud.aws.credentials.access-key}")
-    private String accessKey;
-
-    @Value("${cloud.aws.credentials.secret-key}")
-    private String secretKey;
-
     @Value("${cloud.aws.region.static:ap-northeast-2}")
     private String region;
 
@@ -30,9 +23,7 @@ public class AwsTranslateConfig {
     public TranslateClient translateClient() {
         return TranslateClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)
-                ))
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 
@@ -40,9 +31,7 @@ public class AwsTranslateConfig {
     public BedrockRuntimeClient bedrockRuntimeClient() {
         return BedrockRuntimeClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)
-                ))
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .httpClient(UrlConnectionHttpClient.builder()
                         .socketTimeout(Duration.ofMinutes(3))
                         .connectionTimeout(Duration.ofSeconds(10))

--- a/src/main/java/server/nadeliv/config/SesConfig.java
+++ b/src/main/java/server/nadeliv/config/SesConfig.java
@@ -3,19 +3,12 @@ package server.nadeliv.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ses.SesClient;
 
 @Configuration
 public class SesConfig {
-
-    @Value("${cloud.aws.credentials.access-key}")
-    private String accessKey;
-
-    @Value("${cloud.aws.credentials.secret-key}")
-    private String secretKey;
 
     @Value("${cloud.aws.ses.region:ap-northeast-2}")
     private String sesRegion;
@@ -24,9 +17,7 @@ public class SesConfig {
     public SesClient sesClient() {
         return SesClient.builder()
                 .region(Region.of(sesRegion))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)
-                ))
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 }

--- a/src/main/java/server/nadeliv/translate/service/serviceImpl/TranslationServiceImpl.java
+++ b/src/main/java/server/nadeliv/translate/service/serviceImpl/TranslationServiceImpl.java
@@ -14,8 +14,7 @@ import server.nadeliv.translate.model.enums.ExportFormat;
 import server.nadeliv.translate.repo.TranslationHistoryCustomRepo;
 import server.nadeliv.translate.repo.TranslationHistoryRepo;
 import server.nadeliv.translate.service.TranslationService;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
@@ -42,12 +41,6 @@ public class TranslationServiceImpl implements TranslationService {
     private final TranslationHistoryRepo translationHistoryRepo;
     private final TranslationHistoryCustomRepo translationHistoryCustomRepo;
     private final ObjectMapper objectMapper = new ObjectMapper();
-
-    @Value("${cloud.aws.credentials.access-key}")
-    private String awsAccessKey;
-
-    @Value("${cloud.aws.credentials.secret-key}")
-    private String awsSecretKey;
 
     @Value("${cloud.aws.region.static}")
     private String awsRegion;
@@ -126,9 +119,7 @@ public class TranslationServiceImpl implements TranslationService {
         try {
             BedrockRuntimeClient bedrockClient = BedrockRuntimeClient.builder()
                     .region(Region.of(awsRegion))
-                    .credentialsProvider(StaticCredentialsProvider.create(
-                            AwsBasicCredentials.create(awsAccessKey, awsSecretKey)
-                    ))
+                    .credentialsProvider(DefaultCredentialsProvider.create())
                     .build();
 
             String systemPrompt = String.format(


### PR DESCRIPTION
S3/SES/Translate/Bedrock 클라이언트가 StaticCredentialsProvider + @Value(cloud.aws.credentials.*) 로 정적 키를 강제하던 것을
DefaultCredentialsProvider 로 변경. EC2 에서는 인스턴스 역할
(nadeliv-backend-role), 로컬에서는 ~/.aws/credentials 로 자동 해석된다.

- AwsS3Config / SesConfig / AwsTranslateConfig / TranslationServiceImpl: StaticCredentialsProvider → DefaultCredentialsProvider, 키 @Value 제거
- deploy.yml: AWS_ACCESS_KEY/SECRET_KEY env 주입 및 application.yml cloud.aws.credentials 블록 제거 (region/bedrock/ses 는 유지)

주의: 운영 반영 시 production 배포(새 jar)를 먼저 적용한 뒤
옛 IAM 키를 폐기할 것. 순서를 뒤집으면 옛 jar 가 AccessDenied 로 장애.