### PR TITLE
feat(blog): 에디터 파일 업로드 백엔드 엔드포인트 추가

### DIFF
--- a/src/main/java/server/nadeliv/blog/controller/FileController.java
+++ b/src/main/java/server/nadeliv/blog/controller/FileController.java
@@ -1,0 +1,41 @@
+package server.nadeliv.blog.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import server.nadeliv.blog.dto.FileUploadResponse;
+import server.nadeliv.blog.service.FileService;
+import server.nadeliv.users.dto.CustomUserDetails;
+
+@RestController
+@RequestMapping("/api/v1/files")
+@RequiredArgsConstructor
+@Slf4j
+public class FileController {
+
+    private final FileService fileService;
+
+    /**
+     * 에디터 이미지·비디오 업로드 (인증 필요).
+     * 프론트는 multipart/form-data 로 file + fileKey 를 전송하고, 공개 S3 URL 을 돌려받는다.
+     */
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> upload(
+            @RequestPart("file") MultipartFile file,
+            @RequestParam("fileKey") String fileKey,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        try {
+            String url = fileService.uploadBlogFile(file, fileKey);
+            return ResponseEntity.ok(FileUploadResponse.builder().url(url).build());
+        } catch (Exception e) {
+            log.error("파일 업로드 실패: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("파일 업로드 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/server/nadeliv/blog/dto/FileUploadResponse.java
+++ b/src/main/java/server/nadeliv/blog/dto/FileUploadResponse.java
@@ -1,0 +1,15 @@
+package server.nadeliv.blog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FileUploadResponse {
+    // 업로드된 파일의 공개 S3 URL (에디터 <img src>/<video src>에 그대로 사용)
+    private String url;
+}

--- a/src/main/java/server/nadeliv/blog/service/FileService.java
+++ b/src/main/java/server/nadeliv/blog/service/FileService.java
@@ -1,0 +1,16 @@
+package server.nadeliv.blog.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileService {
+
+    /**
+     * 블로그/댓글 에디터 이미지·비디오를 S3(haries-img)에 업로드하고 공개 URL을 반환한다.
+     * 프론트가 더 이상 AWS 키로 브라우저에서 직접 업로드하지 않고 이 엔드포인트를 경유한다.
+     *
+     * @param file    업로드할 파일 (image/* 또는 video/* 만 허용)
+     * @param fileKey S3 object key (예: new/{uuid}, {documentId}/{uuid}, comments/{documentId}/{uuid})
+     * @return 업로드된 객체의 공개 URL
+     */
+    String uploadBlogFile(MultipartFile file, String fileKey);
+}

--- a/src/main/java/server/nadeliv/blog/service/serviceImpl/FileServiceImpl.java
+++ b/src/main/java/server/nadeliv/blog/service/serviceImpl/FileServiceImpl.java
@@ -1,0 +1,78 @@
+package server.nadeliv.blog.service.serviceImpl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import server.nadeliv.blog.service.FileService;
+import server.nadeliv.error.CustomException;
+import server.nadeliv.error.ErrorCode;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileServiceImpl implements FileService {
+
+    private final S3Client s3Client;
+
+    private static final String BUCKET_NAME = "haries-img";
+    private static final String REGION = "ap-northeast-2";
+
+    // 허용 문자: 영숫자 / . _ - (경로 구분자 /). 첫 글자는 영숫자.
+    private static final Pattern SAFE_KEY = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._/-]*$");
+
+    @Override
+    public String uploadBlogFile(MultipartFile file, String fileKey) {
+        validateFileKey(fileKey);
+        validateMediaType(file);
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(fileKey)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .build();
+
+            s3Client.putObject(putObjectRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            String fileUrl = "https://" + BUCKET_NAME + ".s3." + REGION + ".amazonaws.com/" + fileKey;
+            log.info("Blog S3 upload success: {}", fileUrl);
+            return fileUrl;
+        } catch (IOException e) {
+            log.error("Blog S3 upload failed: {}", e.getMessage());
+            throw new CustomException(ErrorCode.S3_UPLOAD_FAILED, e.getMessage());
+        }
+    }
+
+    /**
+     * path traversal · 절대경로 · 임의 버킷 지정 차단.
+     * 인증된 사용자라도 의도하지 않은 위치에 쓰지 못하도록 key 형식을 엄격히 제한한다.
+     */
+    private void validateFileKey(String fileKey) {
+        if (fileKey == null
+                || fileKey.isBlank()
+                || fileKey.startsWith("/")
+                || fileKey.contains("..")
+                || fileKey.contains("\\")
+                || fileKey.contains("://")
+                || !SAFE_KEY.matcher(fileKey).matches()) {
+            throw new CustomException(ErrorCode.INVALID_FILE_KEY, fileKey);
+        }
+    }
+
+    private void validateMediaType(MultipartFile file) {
+        String contentType = file.getContentType();
+        if (contentType == null
+                || (!contentType.startsWith("image/") && !contentType.startsWith("video/"))) {
+            throw new CustomException(ErrorCode.INVALID_MEDIA_TYPE);
+        }
+    }
+}

--- a/src/main/java/server/nadeliv/error/ErrorCode.java
+++ b/src/main/java/server/nadeliv/error/ErrorCode.java
@@ -90,6 +90,9 @@ public enum ErrorCode {
     TRAVEL_CHANNEL_NOT_FOUND(HttpStatus.NOT_FOUND, "TRV_015", "여행 채널을 찾을 수 없습니다"),
     CHANNEL_ALREADY_LINKED(HttpStatus.CONFLICT, "TRV_016", "이미 연결된 채널입니다"),
 
+    // ============= 파일 에러 (FILE) =============
+    INVALID_FILE_KEY(HttpStatus.BAD_REQUEST, "FILE_001", "허용되지 않은 파일 경로입니다"),
+
     // ============= 일반 에러 (GEN) =============
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "GEN_001", "Invalid input / 잘못된 입력값입니다"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "GEN_002", "Resource not found"),


### PR DESCRIPTION
브라우저에서 AWS 키로 S3에 직접 업로드하던 것을 백엔드 경유로 전환.
인스턴스 역할 기반 S3Client를 사용하는 FileController(/api/v1/files) 추가.
- FileService/FileServiceImpl: haries-img 업로드, path traversal·MIME 검증
- FileUploadResponse DTO, INVALID_FILE_KEY 에러코드 추가