### PR TITLE
feat: 검색엔진 제출용 sitemap.xml 엔드포인트 추가

### DIFF
--- a/src/main/java/server/nadeliv/blog/controller/SitemapController.java
+++ b/src/main/java/server/nadeliv/blog/controller/SitemapController.java
@@ -1,0 +1,33 @@
+package server.nadeliv.blog.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.nadeliv.blog.service.SitemapService;
+
+/**
+ * 검색엔진용 sitemap.xml (비인증 공개).
+ * www.nadeliv.com/robots.txt 에서 https://api.nadeliv.com/sitemap.xml 로 참조된다.
+ */
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class SitemapController {
+
+    private final SitemapService sitemapService;
+
+    @GetMapping(value = "/sitemap.xml", produces = MediaType.APPLICATION_XML_VALUE)
+    public ResponseEntity<String> getSitemap() {
+        try {
+            return ResponseEntity.ok()
+                    .header("Cache-Control", "public, max-age=3600")
+                    .body(sitemapService.generateSitemapXml());
+        } catch (Exception e) {
+            log.error("sitemap.xml 생성 실패", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/server/nadeliv/blog/repo/BlogsRepo.java
+++ b/src/main/java/server/nadeliv/blog/repo/BlogsRepo.java
@@ -70,4 +70,9 @@ public interface BlogsRepo extends MongoRepository<Documents, String> {
 
     // Featured 설정된 모든 글 (히스토리용)
     Page<Documents> findByFeaturedReadyTrueAndIsDeletedFalse(Pageable pageable);
+
+    // sitemap.xml 용: 발행·공개 글만, 필요한 필드만 프로젝션
+    @Query(value = "{ 'draft': { $ne: true }, 'isDeleted': { $ne: true }, 'disclose': { $ne: false } }",
+            fields = "{ '_id': 1, 'updated': 1, 'created': 1, 'originalLocale': 1 }")
+    List<Documents> findAllForSitemap();
 }

--- a/src/main/java/server/nadeliv/blog/service/SitemapService.java
+++ b/src/main/java/server/nadeliv/blog/service/SitemapService.java
@@ -1,0 +1,5 @@
+package server.nadeliv.blog.service;
+
+public interface SitemapService {
+    String generateSitemapXml();
+}

--- a/src/main/java/server/nadeliv/blog/service/serviceImpl/SitemapServiceImpl.java
+++ b/src/main/java/server/nadeliv/blog/service/serviceImpl/SitemapServiceImpl.java
@@ -1,0 +1,112 @@
+package server.nadeliv.blog.service.serviceImpl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import server.nadeliv.blog.model.Documents;
+import server.nadeliv.blog.repo.BlogsRepo;
+import server.nadeliv.blog.service.SitemapService;
+import server.nadeliv.i18n.model.entities.PostTranslation;
+import server.nadeliv.i18n.model.enums.TranslationStatus;
+import server.nadeliv.i18n.repo.PostTranslationRepo;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 검색엔진(Google Search Console, Naver Search Advisor)에 제출할 sitemap.xml 생성.
+ * 발행된(draft 아님, 삭제 아님, 공개) 글의 원본 locale URL + 번역 완료된 locale URL 을 포함한다.
+ * www.nadeliv.com/robots.txt 의 Sitemap 지시자가 이 엔드포인트(api.nadeliv.com/sitemap.xml)를 참조한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SitemapServiceImpl implements SitemapService {
+
+    private final BlogsRepo blogsRepo;
+    private final PostTranslationRepo postTranslationRepo;
+
+    @Value("${nadeliv.sitemap.base-url:https://www.nadeliv.com}")
+    private String baseUrl;
+
+    @Value("${nadeliv.i18n.target-locales:en,zh,ja}")
+    private String targetLocales;
+
+    private static final DateTimeFormatter LASTMOD_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final long CACHE_TTL_MILLIS = 10 * 60 * 1000L; // 10분
+
+    // 트래픽 대비 단순 인메모리 캐시 (문서 수가 적어 Redis 까지는 불필요)
+    private volatile String cachedXml;
+    private volatile long cachedAt;
+
+    @Override
+    public String generateSitemapXml() {
+        String cached = cachedXml;
+        if (cached != null && System.currentTimeMillis() - cachedAt < CACHE_TTL_MILLIS) {
+            return cached;
+        }
+
+        StringBuilder xml = new StringBuilder();
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n");
+
+        // 정적 페이지: 홈 + locale 별 블로그 목록
+        appendUrl(xml, baseUrl + "/", null);
+        appendUrl(xml, baseUrl + "/blog/home/ko", null);
+        for (String locale : targetLocales.split(",")) {
+            appendUrl(xml, baseUrl + "/blog/home/" + locale.trim(), null);
+        }
+
+        // 발행 글: 원본 locale URL
+        List<Documents> publishedDocs = blogsRepo.findAllForSitemap();
+        Set<String> publishedIds = publishedDocs.stream()
+                .map(Documents::getId)
+                .collect(Collectors.toSet());
+
+        for (Documents doc : publishedDocs) {
+            String locale = doc.getOriginalLocale() != null ? doc.getOriginalLocale() : "ko";
+            appendUrl(xml, baseUrl + "/blog/view/" + locale + "/" + doc.getId(),
+                    doc.getUpdated() != null ? doc.getUpdated() : doc.getCreated());
+        }
+
+        // 번역 완료된 글: locale 별 URL (발행 글에 한함)
+        List<PostTranslation> translations = postTranslationRepo.findByStatus(TranslationStatus.COMPLETED);
+        for (PostTranslation translation : translations) {
+            if (!publishedIds.contains(translation.getPostId())) {
+                continue;
+            }
+            appendUrl(xml, baseUrl + "/blog/view/" + translation.getLocale() + "/" + translation.getPostId(),
+                    translation.getUpdatedAt() != null ? translation.getUpdatedAt() : translation.getCreatedAt());
+        }
+
+        xml.append("</urlset>\n");
+
+        String result = xml.toString();
+        cachedXml = result;
+        cachedAt = System.currentTimeMillis();
+        log.info("sitemap.xml 생성 완료: 발행 글 {}건, 번역 {}건", publishedDocs.size(), translations.size());
+        return result;
+    }
+
+    private void appendUrl(StringBuilder xml, String loc, LocalDateTime lastmod) {
+        xml.append("  <url>\n");
+        xml.append("    <loc>").append(escapeXml(loc)).append("</loc>\n");
+        if (lastmod != null) {
+            xml.append("    <lastmod>").append(lastmod.format(LASTMOD_FORMAT)).append("</lastmod>\n");
+        }
+        xml.append("  </url>\n");
+    }
+
+    private String escapeXml(String value) {
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+}

--- a/src/main/java/server/nadeliv/config/SecurityConfig.java
+++ b/src/main/java/server/nadeliv/config/SecurityConfig.java
@@ -78,6 +78,8 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/api/v1/tags/**").permitAll()
                     // 댓글 조회 API (비인증 허용)
                     .requestMatchers(HttpMethod.GET, "/api/v1/comments/**").permitAll()
+                    // 검색엔진용 sitemap (비인증 허용)
+                    .requestMatchers(HttpMethod.GET, "/sitemap.xml").permitAll()
                 .anyRequest().authenticated()
             ).sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/server/nadeliv/i18n/repo/PostTranslationRepo.java
+++ b/src/main/java/server/nadeliv/i18n/repo/PostTranslationRepo.java
@@ -19,6 +19,9 @@ public interface PostTranslationRepo extends MongoRepository<PostTranslation, St
 
     boolean existsByPostIdAndLocale(String postId, String locale);
 
+    // sitemap.xml 용: 번역 완료된 모든 문서 조회
+    List<PostTranslation> findByStatus(TranslationStatus status);
+
     void deleteByPostId(String postId);
 
     // 여러 문서의 번역을 한번에 조회 (블로그 목록용)


### PR DESCRIPTION
- GET /sitemap.xml (비인증 공개): 발행·공개 글의 원본 locale URL + 번역 완료 locale URL + 홈/목록 페이지 포함
- 10분 인메모리 캐시 + Cache-Control 1시간
- BlogsRepo.findAllForSitemap(): draft/isDeleted/disclose 필터 + 필드 프로젝션
- PostTranslationRepo.findByStatus() 추가
- SecurityConfig: /sitemap.xml permitAll ("ps" 매처에 안 걸리는 경로라 명시 필요)
- base-url은 nadeliv.sitemap.base-url 프로퍼티(기본 https://www.nadeliv.com)