### PR TITLE
feat: 블로그 발행·Travel 업로드 일일 남용 방지 레이트 리밋 추가

### DIFF
--- a/src/main/java/server/nadeliv/blog/controller/BlogController.java
+++ b/src/main/java/server/nadeliv/blog/controller/BlogController.java
@@ -17,6 +17,7 @@ import server.nadeliv.blog.dto.PaginationDTO;
 import server.nadeliv.blog.dto.PopularPostDTO;
 import server.nadeliv.blog.model.Documents;
 import server.nadeliv.blog.service.BlogService;
+import server.nadeliv.error.CustomException;
 
 import java.util.HashMap;
 import java.util.List;
@@ -38,6 +39,8 @@ public class BlogController {
         try {
             DocumentsDTO documentsDTO = blogService.createDocument(data);
             return ResponseEntity.ok(documentsDTO);
+        } catch (CustomException e) {
+            throw e; // 발행 한도 초과(429) 등은 GlobalExceptionHandler로 전달
         } catch (Exception e) {
             return null;
         }
@@ -64,6 +67,8 @@ public class BlogController {
         try {
             DocumentsDTO documentsDTO = blogService.saveDocument(data);
             return ResponseEntity.ok(documentsDTO);
+        } catch (CustomException e) {
+            throw e; // 발행 한도 초과(429) 등은 GlobalExceptionHandler로 전달
         } catch (ResponseStatusException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/server/nadeliv/blog/service/serviceImpl/BlogServiceImpl.java
+++ b/src/main/java/server/nadeliv/blog/service/serviceImpl/BlogServiceImpl.java
@@ -29,6 +29,9 @@ import server.nadeliv.blog.model.DocumentView;
 import server.nadeliv.blog.model.Documents;
 import server.nadeliv.blog.repo.BlogsRepo;
 import server.nadeliv.blog.service.BlogService;
+import server.nadeliv.common.service.RateLimitService;
+import server.nadeliv.error.CustomException;
+import server.nadeliv.error.ErrorCode;
 import server.nadeliv.connections.bookmarks.repo.BookmarksRepo;
 import server.nadeliv.connections.follows.service.UserFollowService;
 import server.nadeliv.i18n.model.entities.PostTranslation;
@@ -77,10 +80,17 @@ public class BlogServiceImpl implements BlogService {
     @Autowired
     private UserFollowService userFollowService;
 
+    @Autowired
+    private RateLimitService rateLimitService;
+
     private final ObjectMapper popularObjectMapper = new ObjectMapper();
 
     private static final String POPULAR_CACHE_PREFIX = "blog:popular:";
     private static final Duration POPULAR_CACHE_TTL = Duration.ofMinutes(15);
+
+    // 하루 발행(draft→published 전환) 가능 글 수 제한 (남용 방지)
+    private static final String SCOPE_BLOG_PUBLISH = "blog:publish";
+    private static final int MAX_DAILY_PUBLISH = 8;
 
     private void testAggregationSteps(
             AggregationOperation matchDraft,
@@ -254,11 +264,23 @@ public class BlogServiceImpl implements BlogService {
             String username = userDetails.getUsername();
             documents.setCreatedUser(username);
             documents.setUpdatedUser(username);
+
+            // 남용 방지: 일반 플로우는 draft=true 로 생성하지만, 프론트를 우회해
+            // 바로 발행(draft=false)으로 생성하는 경우도 하루 8개 제한에 포함시킨다.
+            boolean isDirectPublish = !documents.isDraft();
+            if (isDirectPublish && rateLimitService.isDailyLimitReached(SCOPE_BLOG_PUBLISH, username, MAX_DAILY_PUBLISH)) {
+                throw new CustomException(ErrorCode.BLOG_PUBLISH_LIMIT_EXCEEDED);
+            }
+
             if (documents.getFolderId() == null) {
                 Users users = usersRepo.findByUserId(username);
                 documents.setFolderId(users.getId());
             }
             Documents afterDocument = blogsRepo.save(documents);
+
+            if (isDirectPublish) {
+                rateLimitService.incrementDaily(SCOPE_BLOG_PUBLISH, username);
+            }
 
             DocumentsDTO newDocDTO = new DocumentsDTO();
             BeanUtils.copyProperties(afterDocument, newDocDTO);
@@ -301,11 +323,23 @@ public class BlogServiceImpl implements BlogService {
                 documents.setDeletedAt(existing.getDeletedAt());
             }
 
+            // 남용 방지: 새로 발행되는 경우(draft→published 전환)만 하루 8개 제한.
+            // 이미 발행된 글을 다시 저장/수정하는 것은 카운트하지 않는다.
+            boolean isNewPublish = !documents.isDraft() && (existing == null || existing.isDraft());
+            if (isNewPublish && rateLimitService.isDailyLimitReached(SCOPE_BLOG_PUBLISH, username, MAX_DAILY_PUBLISH)) {
+                throw new CustomException(ErrorCode.BLOG_PUBLISH_LIMIT_EXCEEDED);
+            }
+
             if (documents.getFolderId() == null) {
                 Users users = usersRepo.findByUserId(username);
                 documents.setFolderId(users.getId());
             }
             Documents afterDocument = blogsRepo.save(documents);
+
+            // 발행 성공 후에만 카운트 증가 (실패한 저장은 쿼터 소모 안 함)
+            if (isNewPublish) {
+                rateLimitService.incrementDaily(SCOPE_BLOG_PUBLISH, username);
+            }
 
             // i18n: 발행된 글(draft가 아닌)이면 자동 번역 큐잉
             if (!afterDocument.isDraft()) {

--- a/src/main/java/server/nadeliv/common/service/RateLimitService.java
+++ b/src/main/java/server/nadeliv/common/service/RateLimitService.java
@@ -1,0 +1,80 @@
+package server.nadeliv.common.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+/**
+ * 사용자별 "하루 N회" 남용 방지용 공용 레이트 리미터.
+ *
+ * <p>블로그 발행·Travel 파일 업로드 등 특정 사용자가 짧은 시간에 대량 요청을 보내 서버에
+ * 부하를 주는 것을 막기 위한 도메인 무관 카운터. Redis 키에 KST 날짜(yyyy-MM-dd)를 포함해
+ * 자정(Asia/Seoul)에 자연스럽게 초기화되며, TTL 은 죽은 키 정리용이다.
+ *
+ * <p><b>Fail-open 정책</b>: Redis 장애 시 예외를 삼키고 요청을 허용한다. 레이트 리밋은
+ * best-effort 보호막이며, Redis 가 잠깐 흔들린다고 정상 사용자의 글 저장·업로드 같은
+ * 핵심 기능이 막혀서는 안 되기 때문이다. (블로그 번역 큐잉 실패 시 저장은 성공시키는 기존 정책과 동일 기조)
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RateLimitService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String KEY_PREFIX = "ratelimit:";
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
+    // 날짜 기반 키가 실제 초기화를 담당하므로 TTL 은 지난 날짜 키 청소 목적(2일).
+    private static final Duration DAILY_KEY_TTL = Duration.ofDays(2);
+
+    /**
+     * 현재 사용자의 오늘 사용량이 limit 이상이면 true (즉, 한 번 더 하면 한도 초과).
+     * Redis 장애 시 false(허용)로 fail-open.
+     */
+    public boolean isDailyLimitReached(String scope, String userId, int limit) {
+        if (!StringUtils.hasText(userId)) {
+            return false; // 인증은 상위 레이어에서 강제. 식별자 없으면 카운트 불가 → 통과.
+        }
+        try {
+            String v = redisTemplate.opsForValue().get(buildKey(scope, userId));
+            long current = (v == null) ? 0L : Long.parseLong(v);
+            return current >= limit;
+        } catch (Exception e) {
+            log.warn("RateLimit 조회 실패(fail-open, 허용): scope={}, userId={}, err={}", scope, userId, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 오늘 사용량을 원자적으로 1 증가시키고 증가 후 값을 반환. 성공한 작업 직후 호출한다.
+     * 최초 증가 시에만 TTL 을 설정한다. Redis 장애 시 0 을 반환하고 무시(fail-open).
+     */
+    public long incrementDaily(String scope, String userId) {
+        if (!StringUtils.hasText(userId)) {
+            return 0L;
+        }
+        try {
+            String key = buildKey(scope, userId);
+            Long count = redisTemplate.opsForValue().increment(key);
+            if (count != null && count == 1L) {
+                redisTemplate.expire(key, DAILY_KEY_TTL);
+            }
+            return count == null ? 0L : count;
+        } catch (Exception e) {
+            log.warn("RateLimit 증가 실패(fail-open, 무시): scope={}, userId={}, err={}", scope, userId, e.getMessage());
+            return 0L;
+        }
+    }
+
+    private String buildKey(String scope, String userId) {
+        // ratelimit:{scope}:{userId}:{yyyy-MM-dd(KST)}
+        return KEY_PREFIX + scope + ":" + userId + ":" + LocalDate.now(ZONE);
+    }
+}

--- a/src/main/java/server/nadeliv/error/ErrorCode.java
+++ b/src/main/java/server/nadeliv/error/ErrorCode.java
@@ -89,6 +89,10 @@ public enum ErrorCode {
     S3_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TRV_014", "파일 다운로드에 실패했습니다"),
     TRAVEL_CHANNEL_NOT_FOUND(HttpStatus.NOT_FOUND, "TRV_015", "여행 채널을 찾을 수 없습니다"),
     CHANNEL_ALREADY_LINKED(HttpStatus.CONFLICT, "TRV_016", "이미 연결된 채널입니다"),
+    TRAVEL_UPLOAD_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "TRV_017", "하루 업로드 가능한 파일 수(500개)를 초과했습니다"),
+
+    // ============= 블로그 에러 (BLOG) =============
+    BLOG_PUBLISH_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "BLOG_001", "하루 발행 가능한 글 수(8개)를 초과했습니다"),
 
     // ============= 파일 에러 (FILE) =============
     INVALID_FILE_KEY(HttpStatus.BAD_REQUEST, "FILE_001", "허용되지 않은 파일 경로입니다"),

--- a/src/main/java/server/nadeliv/travel/service/serviceImpl/TravelServiceImpl.java
+++ b/src/main/java/server/nadeliv/travel/service/serviceImpl/TravelServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import server.nadeliv.common.service.RateLimitService;
 import server.nadeliv.error.CustomException;
 import server.nadeliv.error.ErrorCode;
 import server.nadeliv.travel.model.dto.*;
@@ -48,6 +49,11 @@ public class TravelServiceImpl implements TravelService {
     private final TravelMapper travelMapper;
     private final S3Service s3Service;
     private final TravelChannelRepo travelChannelRepo;
+    private final RateLimitService rateLimitService;
+
+    // 하루 업로드 가능한 파일 수 제한 (남용 방지)
+    private static final String SCOPE_TRAVEL_UPLOAD = "travel:upload";
+    private static final int MAX_DAILY_UPLOAD = 500;
 
     // ==================== Travel CRUD ====================
 
@@ -359,6 +365,11 @@ public class TravelServiceImpl implements TravelService {
         findTravelById(travelId);
         validateEditPermission(travelId, userId);
 
+        // 남용 방지: 사용자당 하루 업로드 500개 제한. S3 업로드 전에 검사해 불필요한 부하를 막는다.
+        if (rateLimitService.isDailyLimitReached(SCOPE_TRAVEL_UPLOAD, userId, MAX_DAILY_UPLOAD)) {
+            throw new CustomException(ErrorCode.TRAVEL_UPLOAD_LIMIT_EXCEEDED);
+        }
+
         String fileUrl = s3Service.uploadFile(file, travelId);
         String thumbnailUrl = s3Service.buildThumbnailUrl(fileUrl);
 
@@ -382,7 +393,12 @@ public class TravelServiceImpl implements TravelService {
         media.setCreatedUser(userId);
         media.setUpdatedUser(userId);
 
-        return travelMediaRepo.save(media);
+        TravelMedia saved = travelMediaRepo.save(media);
+
+        // 업로드 성공 후에만 카운트 증가 (S3/DB 실패는 쿼터 소모 안 함)
+        rateLimitService.incrementDaily(SCOPE_TRAVEL_UPLOAD, userId);
+
+        return saved;
     }
 
     @Override


### PR DESCRIPTION
대량 글 발행/파일 업로드로 서버에 부하를 주는 남용을 막기 위해
사용자당 일일 제한을 추가한다. 기존 이메일 발송 제한(EMAIL_SEND_LIMIT_EXCEEDED) Redis 카운터 패턴을 따른다.

- RateLimitService(common): 도메인 무관 "사용자당 하루 N회" 카운터. KST 날짜 키로 자정 자동 초기화, 원자적 INCR + TTL, Redis 장애 시 fail-open.
- 블로그 발행 하루 8개: draft→published 전환 시에만 카운트(기존 발행 글 수정은 제외). saveDocument + createDocument(프론트 우회 직접 발행) 방어.
- Travel 파일 업로드 하루 500개: uploadMedia에서 S3 업로드 전 검사.
- ErrorCode: BLOG_PUBLISH_LIMIT_EXCEEDED, TRAVEL_UPLOAD_LIMIT_EXCEEDED (429).
- BlogController: create/saveDocument가 예외를 삼켜 200 반환하던 것을 CustomException re-throw로 수정해 429가 클라이언트까지 전달되게 함.