### PR TITLE
fix(i18n): 번역 파이프라인 잘림·파싱 실패 방어 + sitemap hreflang

### DIFF
--- a/src/main/java/server/nadeliv/blog/service/serviceImpl/SitemapServiceImpl.java
+++ b/src/main/java/server/nadeliv/blog/service/serviceImpl/SitemapServiceImpl.java
@@ -13,13 +13,16 @@ import server.nadeliv.i18n.repo.PostTranslationRepo;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 /**
  * 검색엔진(Google Search Console, Naver Search Advisor)에 제출할 sitemap.xml 생성.
- * 발행된(draft 아님, 삭제 아님, 공개) 글의 원본 locale URL + 번역 완료된 locale URL 을 포함한다.
+ * 발행된(draft 아님, 삭제 아님, 공개) 글의 원본 locale URL + 번역 완료된 locale URL 을 포함하며,
+ * 언어 버전 간 관계를 알리기 위해 xhtml:link rel="alternate" hreflang 을 함께 기재한다.
+ * (hreflang 없이 언어별 URL만 나열하면 검색 결과에 언어가 섞여 노출된다)
  * www.nadeliv.com/robots.txt 의 Sitemap 지시자가 이 엔드포인트(api.nadeliv.com/sitemap.xml)를 참조한다.
  */
 @Service
@@ -52,35 +55,52 @@ public class SitemapServiceImpl implements SitemapService {
 
         StringBuilder xml = new StringBuilder();
         xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-        xml.append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n");
+        xml.append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"")
+                .append(" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\">\n");
 
-        // 정적 페이지: 홈 + locale 별 블로그 목록
-        appendUrl(xml, baseUrl + "/", null);
-        appendUrl(xml, baseUrl + "/blog/home/ko", null);
+        // 홈 (단일 URL, 언어 버전 없음)
+        appendUrl(xml, baseUrl + "/", null, null);
+
+        // locale 별 블로그 목록: 서로가 언어 대체 버전 (x-default = ko)
+        Map<String, String> homeAlternates = new LinkedHashMap<>();
+        homeAlternates.put("ko", baseUrl + "/blog/home/ko");
         for (String locale : targetLocales.split(",")) {
-            appendUrl(xml, baseUrl + "/blog/home/" + locale.trim(), null);
+            String trimmed = locale.trim();
+            homeAlternates.put(trimmed, baseUrl + "/blog/home/" + trimmed);
+        }
+        for (String url : homeAlternates.values()) {
+            appendUrl(xml, url, null, buildAlternates(homeAlternates, homeAlternates.get("ko")));
         }
 
-        // 발행 글: 원본 locale URL
+        // 발행 글 + 번역본: 글 단위로 언어 그룹을 만들어 hreflang 상호 참조
         List<Documents> publishedDocs = blogsRepo.findAllForSitemap();
-        Set<String> publishedIds = publishedDocs.stream()
-                .map(Documents::getId)
-                .collect(Collectors.toSet());
+        List<PostTranslation> translations = postTranslationRepo.findByStatusIn(
+                List.of(TranslationStatus.COMPLETED, TranslationStatus.MANUALLY_EDITED));
+
+        Map<String, List<PostTranslation>> translationsByPost = new LinkedHashMap<>();
+        for (PostTranslation t : translations) {
+            translationsByPost.computeIfAbsent(t.getPostId(), k -> new ArrayList<>()).add(t);
+        }
 
         for (Documents doc : publishedDocs) {
-            String locale = doc.getOriginalLocale() != null ? doc.getOriginalLocale() : "ko";
-            appendUrl(xml, baseUrl + "/blog/view/" + locale + "/" + doc.getId(),
-                    doc.getUpdated() != null ? doc.getUpdated() : doc.getCreated());
-        }
+            String originalLocale = doc.getOriginalLocale() != null ? doc.getOriginalLocale() : "ko";
+            String originalUrl = baseUrl + "/blog/view/" + originalLocale + "/" + doc.getId();
 
-        // 번역 완료된 글: locale 별 URL (발행 글에 한함)
-        List<PostTranslation> translations = postTranslationRepo.findByStatus(TranslationStatus.COMPLETED);
-        for (PostTranslation translation : translations) {
-            if (!publishedIds.contains(translation.getPostId())) {
-                continue;
+            // 언어 그룹: 원본 + 완료된 번역
+            Map<String, String> group = new LinkedHashMap<>();
+            Map<String, LocalDateTime> lastmods = new LinkedHashMap<>();
+            group.put(originalLocale, originalUrl);
+            lastmods.put(originalLocale, doc.getUpdated() != null ? doc.getUpdated() : doc.getCreated());
+
+            for (PostTranslation t : translationsByPost.getOrDefault(doc.getId(), List.of())) {
+                group.put(t.getLocale(), baseUrl + "/blog/view/" + t.getLocale() + "/" + doc.getId());
+                lastmods.put(t.getLocale(), t.getUpdatedAt() != null ? t.getUpdatedAt() : t.getCreatedAt());
             }
-            appendUrl(xml, baseUrl + "/blog/view/" + translation.getLocale() + "/" + translation.getPostId(),
-                    translation.getUpdatedAt() != null ? translation.getUpdatedAt() : translation.getCreatedAt());
+
+            String alternates = buildAlternates(group, originalUrl);
+            for (Map.Entry<String, String> entry : group.entrySet()) {
+                appendUrl(xml, entry.getValue(), lastmods.get(entry.getKey()), alternates);
+            }
         }
 
         xml.append("</urlset>\n");
@@ -92,11 +112,26 @@ public class SitemapServiceImpl implements SitemapService {
         return result;
     }
 
-    private void appendUrl(StringBuilder xml, String loc, LocalDateTime lastmod) {
+    // 언어 그룹 전체의 xhtml:link alternate 블록 생성 (그룹 내 모든 URL 이 동일 블록을 공유)
+    private String buildAlternates(Map<String, String> group, String xDefaultUrl) {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, String> entry : group.entrySet()) {
+            sb.append("    <xhtml:link rel=\"alternate\" hreflang=\"").append(entry.getKey())
+                    .append("\" href=\"").append(escapeXml(entry.getValue())).append("\"/>\n");
+        }
+        sb.append("    <xhtml:link rel=\"alternate\" hreflang=\"x-default\" href=\"")
+                .append(escapeXml(xDefaultUrl)).append("\"/>\n");
+        return sb.toString();
+    }
+
+    private void appendUrl(StringBuilder xml, String loc, LocalDateTime lastmod, String alternates) {
         xml.append("  <url>\n");
         xml.append("    <loc>").append(escapeXml(loc)).append("</loc>\n");
         if (lastmod != null) {
             xml.append("    <lastmod>").append(lastmod.format(LASTMOD_FORMAT)).append("</lastmod>\n");
+        }
+        if (alternates != null) {
+            xml.append(alternates);
         }
         xml.append("  </url>\n");
     }

--- a/src/main/java/server/nadeliv/i18n/controller/I18nController.java
+++ b/src/main/java/server/nadeliv/i18n/controller/I18nController.java
@@ -187,4 +187,25 @@ public class I18nController {
                     .body("Batch translation failed: " + e.getMessage());
         }
     }
+
+    /**
+     * 깨진 번역(잘린 모델 응답이 그대로 저장된 건) 탐지 후 재번역 큐잉.
+     */
+    @PostMapping("/admin/repair-broken-translations")
+    public ResponseEntity<?> repairBrokenTranslations(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        try {
+            int queuedCount = i18nTranslationService.repairBrokenTranslations();
+            return ResponseEntity.accepted()
+                    .body(java.util.Map.of(
+                            "message", "Broken translations re-queued",
+                            "queuedTranslations", queuedCount
+                    ));
+        } catch (Exception e) {
+            log.error("깨진 번역 복구 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Repair failed: " + e.getMessage());
+        }
+    }
 }

--- a/src/main/java/server/nadeliv/i18n/repo/PostTranslationRepo.java
+++ b/src/main/java/server/nadeliv/i18n/repo/PostTranslationRepo.java
@@ -22,6 +22,9 @@ public interface PostTranslationRepo extends MongoRepository<PostTranslation, St
     // sitemap.xml 용: 번역 완료된 모든 문서 조회
     List<PostTranslation> findByStatus(TranslationStatus status);
 
+    // sitemap.xml 용: 완료(COMPLETED) + 수동편집(MANUALLY_EDITED) 번역 일괄 조회
+    List<PostTranslation> findByStatusIn(List<TranslationStatus> statuses);
+
     void deleteByPostId(String postId);
 
     // 여러 문서의 번역을 한번에 조회 (블로그 목록용)

--- a/src/main/java/server/nadeliv/i18n/service/BedrockPostTranslationClient.java
+++ b/src/main/java/server/nadeliv/i18n/service/BedrockPostTranslationClient.java
@@ -1,6 +1,9 @@
 package server.nadeliv.i18n.service;
 
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,14 +11,20 @@ import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.*;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * AWS Bedrock (Claude)를 사용한 블로그 글 번역 클라이언트.
- * HTML 태그를 플레이스홀더로 보호하여 번역 시 태그 손상 방지.
+ * - HTML 태그를 플레이스홀더로 보호하여 번역 시 태그 손상 방지.
+ * - 긴 글은 청크 분할 번역으로 max output tokens 잘림 방지.
+ * - 응답 파싱 실패 시 예외를 던져 Job 재시도/FAILED 처리로 넘긴다.
+ *   (잘린 원문 응답을 번역 결과로 저장하면 안 됨 — SEO 오염의 원인)
  */
 @Slf4j
 @Component
@@ -23,29 +32,66 @@ import java.util.regex.Pattern;
 public class BedrockPostTranslationClient {
 
     private final BedrockRuntimeClient bedrockRuntimeClient;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 모델이 JSON 문자열 내 제어문자를 이스케이프하지 않는 경우가 있어 관대하게 파싱
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS)
+            .build();
 
     @Value("${cloud.aws.bedrock.model-id}")
     private String modelId;
 
+    @Value("${nadeliv.i18n.max-output-tokens:8192}")
+    private int maxOutputTokens;
+
+    // 청크 분할 기준 (플레이스홀더 치환 후 원문 문자 수).
+    // 출력 언어(zh/ja)는 문자당 토큰 수가 높아 보수적으로 설정.
+    @Value("${nadeliv.i18n.chunk-size-chars:3000}")
+    private int chunkSizeChars;
+
     private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<[^>]+>");
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\[\\[PH_\\d+]]");
 
-    private static final String SYSTEM_PROMPT = """
-            You are a professional travel blog translator.
-            Translate the following travel blog content from %s to %s.
-
+    private static final String COMMON_RULES = """
             RULES:
             1. Maintain the casual, personal tone of a travel blogger.
             2. The content contains [[PH_N]] placeholders (e.g., [[PH_1]], [[PH_2]]) representing HTML tags. Preserve ALL placeholders exactly as-is. Do not modify, translate, remove, or reorder them.
             3. Only translate the text between placeholders.
-            4. Keep place names in their commonly used form in the target language.
+            4. Keep place names in their commonly used form in the target language. Korean place names should be transliterated/translated to their standard form in the target language (e.g., 월출산 → Wolchulsan / 月出山).
             5. Do NOT translate proper nouns (hotel names, restaurant names, brand names).
             6. Adapt cultural references and idioms naturally.
             7. Match the paragraph structure of the original.
             8. For prices, keep original amounts but adapt currency notation.
+            9. Inside JSON string values, escape double quotes and newlines properly (\\" and \\n).
+            """;
+
+    private static final String FULL_SYSTEM_PROMPT = """
+            You are a professional travel blog translator.
+            Translate the following travel blog content from %s to %s.
+
+            """ + COMMON_RULES + """
 
             Respond ONLY in this JSON format without any markdown or code blocks:
             {"title": "translated title", "content": "translated content with [[PH_N]] placeholders preserved", "summary": "translated summary"}
+            """;
+
+    private static final String CHUNK_SYSTEM_PROMPT = """
+            You are a professional travel blog translator.
+            Translate the following fragment of a travel blog post from %s to %s.
+
+            """ + COMMON_RULES + """
+
+            Respond ONLY in this JSON format without any markdown or code blocks:
+            {"text": "translated fragment with [[PH_N]] placeholders preserved"}
+            """;
+
+    private static final String TITLE_SYSTEM_PROMPT = """
+            You are a professional travel blog translator.
+            Translate the following travel blog title and summary from %s to %s.
+            Keep place names in their standard form in the target language.
+
+            Respond ONLY in this JSON format without any markdown or code blocks:
+            {"title": "translated title", "summary": "translated summary"}
             """;
 
     public TranslationResult translate(String title, String content, String summary,
@@ -55,53 +101,188 @@ public class BedrockPostTranslationClient {
             Map<String, String> tagMap = new LinkedHashMap<>();
             String protectedContent = protectHtmlTags(content, tagMap);
 
-            log.info("HTML 태그 보호: {} 개 태그를 플레이스홀더로 치환", tagMap.size());
+            log.info("HTML 태그 보호: {} 개 태그를 플레이스홀더로 치환, 원문 {}자 → 보호 후 {}자",
+                    tagMap.size(), content != null ? content.length() : 0,
+                    protectedContent != null ? protectedContent.length() : 0);
 
-            String systemPrompt = String.format(SYSTEM_PROMPT,
-                    getLanguageName(sourceLocale),
-                    getLanguageName(targetLocale));
+            String source = getLanguageName(sourceLocale);
+            String target = getLanguageName(targetLocale);
 
-            String userMessage = String.format("""
-                    Title: %s
-
-                    Summary: %s
-
-                    Content:
-                    %s
-                    """, title,
-                    summary != null ? summary : "",
-                    protectedContent);
-
-            ConverseRequest converseRequest = ConverseRequest.builder()
-                    .modelId(modelId)
-                    .system(SystemContentBlock.builder().text(systemPrompt).build())
-                    .messages(Message.builder()
-                            .role(ConversationRole.USER)
-                            .content(ContentBlock.fromText(userMessage))
-                            .build())
-                    .build();
-
-            ConverseResponse response = bedrockRuntimeClient.converse(converseRequest);
-            String responseText = response.output().message().content().get(0).text().trim();
-
-            try {
-                @SuppressWarnings("unchecked")
-                Map<String, String> parsed = objectMapper.readValue(responseText, Map.class);
-                return new TranslationResult(
-                        unescapeHtmlEntities(parsed.getOrDefault("title", title)),
-                        restoreHtmlTags(parsed.getOrDefault("content", protectedContent), tagMap),
-                        unescapeHtmlEntities(parsed.get("summary")),
-                        modelId
-                );
-            } catch (Exception e) {
-                log.warn("Bedrock 응답 JSON 파싱 실패, 전체 응답을 content로 사용: {}", e.getMessage());
-                return new TranslationResult(title, restoreHtmlTags(responseText, tagMap), summary, modelId);
+            TranslationResult result;
+            if (protectedContent == null || protectedContent.length() <= chunkSizeChars) {
+                result = translateSingle(title, protectedContent, summary, source, target, tagMap);
+            } else {
+                result = translateChunked(title, protectedContent, summary, source, target, tagMap);
             }
 
+            // 최종 검증: 복원되지 않은 플레이스홀더가 남아 있으면 실패 처리
+            if (result.content() != null && result.content().contains("[[PH")) {
+                throw new IllegalStateException("Unrestored placeholders remain in translated content");
+            }
+            return result;
+
         } catch (Exception e) {
-            log.error("Bedrock 번역 API 호출 실패 ({}→{}): {}", sourceLocale, targetLocale, e.getMessage());
+            log.error("Bedrock 번역 실패 ({}→{}): {}", sourceLocale, targetLocale, e.getMessage());
             throw new RuntimeException("Translation failed: " + e.getMessage(), e);
         }
+    }
+
+    /** 짧은 글: title+summary+content 한 번에 번역 */
+    private TranslationResult translateSingle(String title, String protectedContent, String summary,
+                                              String source, String target, Map<String, String> tagMap) {
+        String systemPrompt = String.format(FULL_SYSTEM_PROMPT, source, target);
+        String userMessage = String.format("""
+                Title: %s
+
+                Summary: %s
+
+                Content:
+                %s
+                """, title, summary != null ? summary : "", protectedContent);
+
+        JsonNode parsed = invokeAndParse(systemPrompt, userMessage);
+
+        String translatedTitle = textOrThrow(parsed, "title");
+        String translatedContent = parsed.hasNonNull("content") ? parsed.get("content").asText() : null;
+        if (translatedContent == null) {
+            throw new IllegalStateException("Model response missing 'content' field");
+        }
+        String translatedSummary = parsed.hasNonNull("summary") ? parsed.get("summary").asText() : null;
+
+        return new TranslationResult(
+                unescapeHtmlEntities(translatedTitle),
+                restoreHtmlTags(translatedContent, tagMap),
+                unescapeHtmlEntities(translatedSummary),
+                modelId
+        );
+    }
+
+    /** 긴 글: title/summary 1회 + content 청크별 번역 후 결합 */
+    private TranslationResult translateChunked(String title, String protectedContent, String summary,
+                                               String source, String target, Map<String, String> tagMap) {
+        // 1) title + summary
+        String titlePrompt = String.format(TITLE_SYSTEM_PROMPT, source, target);
+        String titleMessage = String.format("Title: %s%n%nSummary: %s",
+                title, summary != null ? summary : "");
+        JsonNode titleParsed = invokeAndParse(titlePrompt, titleMessage);
+        String translatedTitle = textOrThrow(titleParsed, "title");
+        String translatedSummary = titleParsed.hasNonNull("summary") ? titleParsed.get("summary").asText() : null;
+
+        // 2) content 청크 분할 (플레이스홀더는 절대 쪼개지 않음)
+        List<String> chunks = splitByPlaceholders(protectedContent);
+        log.info("청크 분할 번역: {} 개 청크 (청크당 최대 {}자)", chunks.size(), chunkSizeChars);
+
+        String chunkPrompt = String.format(CHUNK_SYSTEM_PROMPT, source, target);
+        StringBuilder translatedContent = new StringBuilder();
+        for (int i = 0; i < chunks.size(); i++) {
+            JsonNode chunkParsed = invokeAndParse(chunkPrompt, chunks.get(i));
+            String text = textOrThrow(chunkParsed, "text");
+            translatedContent.append(text);
+            log.info("청크 {}/{} 번역 완료 ({}자 → {}자)",
+                    i + 1, chunks.size(), chunks.get(i).length(), text.length());
+        }
+
+        return new TranslationResult(
+                unescapeHtmlEntities(translatedTitle),
+                restoreHtmlTags(translatedContent.toString(), tagMap),
+                unescapeHtmlEntities(translatedSummary),
+                modelId
+        );
+    }
+
+    /** Bedrock 호출 + 잘림 검사 + JSON 추출/파싱. 실패 시 예외. */
+    private JsonNode invokeAndParse(String systemPrompt, String userMessage) {
+        ConverseRequest converseRequest = ConverseRequest.builder()
+                .modelId(modelId)
+                .system(SystemContentBlock.builder().text(systemPrompt).build())
+                .messages(Message.builder()
+                        .role(ConversationRole.USER)
+                        .content(ContentBlock.fromText(userMessage))
+                        .build())
+                // temperature/top_p/top_k 는 Sonnet 5 이상에서 제거됨 (전송 시 ValidationException).
+                // 출력 톤은 시스템 프롬프트로만 제어한다.
+                .inferenceConfig(InferenceConfiguration.builder()
+                        .maxTokens(maxOutputTokens)
+                        .build())
+                .build();
+
+        ConverseResponse response = bedrockRuntimeClient.converse(converseRequest);
+
+        // 출력 토큰 한도로 잘린 응답은 불완전한 JSON → 즉시 실패 (재시도 대상)
+        if (response.stopReason() == StopReason.MAX_TOKENS) {
+            throw new IllegalStateException("Model response truncated (max_tokens reached)");
+        }
+
+        // Sonnet 5 이상은 adaptive thinking 이 기본 ON 이라 응답 첫 블록이 reasoningContent 일 수 있다.
+        // content.get(0) 을 그대로 읽으면 번역문이 아닌 추론 블록을 집어 NPE 가 난다. 반드시 text 블록을 찾을 것.
+        String responseText = response.output().message().content().stream()
+                .map(ContentBlock::text)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Model response contained no text block"))
+                .trim();
+        String json = extractJson(responseText);
+        try {
+            return objectMapper.readTree(json);
+        } catch (Exception e) {
+            log.warn("Bedrock 응답 JSON 파싱 실패 (앞 200자): {}", json.substring(0, Math.min(200, json.length())));
+            throw new IllegalStateException("Failed to parse model JSON response: " + e.getMessage(), e);
+        }
+    }
+
+    /** 마크다운 코드펜스 제거 + 첫 '{'부터 마지막 '}'까지 추출 */
+    private String extractJson(String text) {
+        String cleaned = text
+                .replaceAll("(?s)^\\s*```(?:json)?\\s*", "")
+                .replaceAll("(?s)\\s*```\\s*$", "")
+                .trim();
+        int start = cleaned.indexOf('{');
+        int end = cleaned.lastIndexOf('}');
+        if (start >= 0 && end > start) {
+            return cleaned.substring(start, end + 1);
+        }
+        return cleaned;
+    }
+
+    private String textOrThrow(JsonNode node, String field) {
+        if (!node.hasNonNull(field)) {
+            throw new IllegalStateException("Model response missing '" + field + "' field");
+        }
+        return node.get(field).asText();
+    }
+
+    /**
+     * 플레이스홀더 경계 기준으로 청크 분할.
+     * 플레이스홀더/텍스트 단위를 순서대로 누적하다가 chunkSizeChars 초과 시 새 청크 시작.
+     */
+    private List<String> splitByPlaceholders(String protectedContent) {
+        List<String> units = new ArrayList<>();
+        Matcher matcher = PLACEHOLDER_PATTERN.matcher(protectedContent);
+        int last = 0;
+        while (matcher.find()) {
+            if (matcher.start() > last) {
+                units.add(protectedContent.substring(last, matcher.start()));
+            }
+            units.add(matcher.group());
+            last = matcher.end();
+        }
+        if (last < protectedContent.length()) {
+            units.add(protectedContent.substring(last));
+        }
+
+        List<String> chunks = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        for (String unit : units) {
+            if (current.length() > 0 && current.length() + unit.length() > chunkSizeChars) {
+                chunks.add(current.toString());
+                current = new StringBuilder();
+            }
+            current.append(unit);
+        }
+        if (current.length() > 0) {
+            chunks.add(current.toString());
+        }
+        return chunks;
     }
 
     /**
@@ -127,7 +308,7 @@ public class BedrockPostTranslationClient {
      * 번역 후 [[PH_N]] 플레이스홀더를 원래 HTML 태그로 복원.
      */
     private String restoreHtmlTags(String text, Map<String, String> tagMap) {
-        if (text == null || tagMap.isEmpty()) return text;
+        if (text == null || tagMap.isEmpty()) return unescapeHtmlEntities(text);
         String result = text;
         for (Map.Entry<String, String> entry : tagMap.entrySet()) {
             result = result.replace(entry.getKey(), entry.getValue());

--- a/src/main/java/server/nadeliv/i18n/service/I18nTranslationService.java
+++ b/src/main/java/server/nadeliv/i18n/service/I18nTranslationService.java
@@ -38,4 +38,7 @@ public interface I18nTranslationService {
 
     // 관리자용: 기존 글 일괄 번역 큐잉
     int queueAllExistingPosts();
+
+    // 관리자용: 깨진 번역(잘린 JSON 원문 저장분) 탐지 후 재번역 큐잉
+    int repairBrokenTranslations();
 }

--- a/src/main/java/server/nadeliv/i18n/service/serviceImpl/I18nTranslationServiceImpl.java
+++ b/src/main/java/server/nadeliv/i18n/service/serviceImpl/I18nTranslationServiceImpl.java
@@ -446,6 +446,51 @@ public class I18nTranslationServiceImpl implements I18nTranslationService {
         return queued;
     }
 
+    @Override
+    public int repairBrokenTranslations() {
+        // 깨진 번역 = 파싱 실패로 모델 원문 응답(JSON 통째)이 content로 저장됐거나
+        // 플레이스홀더가 복원되지 않은 채 남아 있는 COMPLETED 번역
+        List<PostTranslation> completed = postTranslationRepo.findByStatus(TranslationStatus.COMPLETED);
+        LocalDateTime now = LocalDateTime.now();
+        int queued = 0;
+
+        for (PostTranslation t : completed) {
+            if (!isBrokenContent(t.getContent())) continue;
+
+            log.info("깨진 번역 감지 → 재큐잉: postId={}, locale={}", t.getPostId(), t.getLocale());
+
+            t.setStatus(TranslationStatus.PENDING);
+            t.setUpdatedAt(now);
+            postTranslationRepo.save(t);
+
+            Optional<TranslationJob> activeJob = translationJobRepo
+                    .findByPostIdAndTargetLocaleAndStatusIn(
+                            t.getPostId(), t.getLocale(),
+                            List.of(JobStatus.QUEUED, JobStatus.PROCESSING));
+            if (activeJob.isEmpty()) {
+                translationJobRepo.save(TranslationJob.builder()
+                        .postId(t.getPostId())
+                        .targetLocale(t.getLocale())
+                        .status(JobStatus.QUEUED)
+                        .createdAt(now)
+                        .build());
+            }
+            queued++;
+        }
+
+        log.info("깨진 번역 복구 큐잉 완료: {} 건", queued);
+        return queued;
+    }
+
+    // 깨진 번역 판별: content가 모델 JSON 응답 원문이거나 미복원 플레이스홀더 포함
+    private boolean isBrokenContent(String content) {
+        if (content == null) return false;
+        String trimmed = content.strip();
+        boolean looksLikeRawJson = trimmed.startsWith("{")
+                && (trimmed.contains("\"title\"") || trimmed.contains("\"content\""));
+        return looksLikeRawJson || content.contains("[[PH");
+    }
+
     // availableLocales 빌드 헬퍼
     private List<AvailableLocaleDTO> buildAvailableLocales(String originalLocale,
                                                             List<PostTranslation> translations) {


### PR DESCRIPTION
- BedrockPostTranslationClient: 파싱 실패 시 원문 응답을 번역으로 저장하던 fallback 제거(예외 던져 재시도/FAILED 처리), max_tokens 잘림 감지, 긴 글 청크 분할 번역, reasoningContent 블록 대응, 플레이스홀더 복원 검증
- repair-broken-translations 어드민 엔드포인트: 깨진 COMPLETED 번역 (모델 JSON 원문/미복원 플레이스홀더) 탐지 후 재번역 큐잉
- SitemapServiceImpl: 언어 그룹별 xhtml:link hreflang(자기참조+상호참조 +x-default) 기재, MANUALLY_EDITED 번역도 포함